### PR TITLE
chore: add permission to write tags to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       url: https://pypi.org/p/django-json-agg
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # Required for pushing tags - https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Per Github Actions documentation, 'contents: write' is required to create a release.

> Work with the contents of the repository. For example, contents: read permits an action to list the commits, and contents: write allows the action to create a release.

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions